### PR TITLE
Add firebase mock in Jest setup

### DIFF
--- a/config/jest/setupTests.ts
+++ b/config/jest/setupTests.ts
@@ -4,6 +4,17 @@
 // global mocks
 jest.mock('aws-amplify')
 jest.mock('web-vitals')
+jest.mock('@/firebase', () => ({
+  auth: {
+    currentUser: null,
+    onAuthStateChanged: jest.fn(),
+  },
+  db: {},
+  FIREBASE_INDEX_ERROR_NAME: 'FirebaseError',
+  FIREBASE_INDEX_CREATE_REQUIRED:
+    'Index creation required. Please visit the following URL to create the necessary index:',
+  FIREBASE_INDEX_ERROR_CONTENT: 'The query requires an index',
+}))
 
 // enable mocking of fetch requests
 import { enableFetchMocks } from 'jest-fetch-mock'


### PR DESCRIPTION
## Summary
- mock `@/firebase` in Jest setupTests so tests don't require real Firebase

## Testing
- `npx tsc -p tsconfig.tmp.json --noEmit` *(compilation check)*
- `yarn test` *(fails: Invalid return value in cssTransform and some tests)*