### PR TITLE
fix: Correct typography prop typo

### DIFF
--- a/src/components/Copyright.tsx
+++ b/src/components/Copyright.tsx
@@ -10,19 +10,19 @@ import { COPYRIGHT_LABEL, ORG_NAME, ORG_URL } from '@/constants'
 
 type CopyrightProps = {
   sx?: SxProps
-  typograpyProps?: TypographyProps
+  typographyProps?: TypographyProps
 }
 
 const Copyright: React.FC<CopyrightProps> = ({
   sx,
-  typograpyProps,
+  typographyProps,
 }): React.JSX.Element => (
   <Container sx={{ m: 1, p: 2, ...sx }}>
     <Typography
       variant="body2"
       color="text.secondary"
       align="center"
-      {...typograpyProps}
+      {...typographyProps}
     >
       {`${COPYRIGHT_LABEL}`}{' '}
       <Link color="inherit" href={ORG_URL}>

--- a/src/components/stories/Copyright.stories.tsx
+++ b/src/components/stories/Copyright.stories.tsx
@@ -7,7 +7,7 @@ export default {
   title: 'Components/Copyright',
   component: Copyright,
   argTypes: {
-    typograpyProps: { control: 'object' },
+    typographyProps: { control: 'object' },
     sx: { control: 'object' },
   },
 } as Meta<typeof Copyright>
@@ -15,7 +15,7 @@ export default {
 export const Default: Story = {}
 
 export const WithTypographyProps: Story = {
-  render: () => <Copyright typograpyProps={{ color: 'text.primary' }} />,
+  render: () => <Copyright typographyProps={{ color: 'text.primary' }} />,
   parameters: {
     title: 'With typography props',
   },


### PR DESCRIPTION
## Summary
- rename `typograpyProps` to `typographyProps`
- update storybook and prop types

## Testing
- `yarn ci`
