### PR TITLE
fix(build): exclude tests from prod tsconfig

### DIFF
--- a/tsconfig.prod.json
+++ b/tsconfig.prod.json
@@ -1,6 +1,12 @@
 {
   "extends": "./tsconfig",
-  "exclude": ["./src/__tests__/**", "./src/__mocks__/**", "./src/test-utils"],
+  "exclude": [
+    "./src/__tests__/**",
+    "./src/__mocks__/**",
+    "./src/test-utils",
+    "**/*.test.ts",
+    "**/*.test.tsx"
+  ],
   "compilerOptions": {
     "noUnusedLocals": false
   }


### PR DESCRIPTION
## Summary
- prevent `.test.ts` and `.test.tsx` files from being included in production TypeScript compilation

## Testing
- `yarn build`
- `yarn test`
