### PR TITLE
build(package): allow node v20 or v22

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,13 @@
   "version": "0.0.0-semantic-release",
   "license": "UNLICENSED",
   "description": "Sinan Bolel's personal website",
-  "homepage": "https://github.com/sbolel/website",
+  "homepage": "https://sinanbolel.com",
   "bugs": {
-    "url": "https://github.com/sbolel/website/issues"
+    "url": "https://github.com/sbolel/sinanbolel-com-v2/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/sbolel/sinanbolel-com-v2.git"
   },
   "author": "Sinan Bolel (https://sinanbolel.com)",
   "contributors": [
@@ -15,7 +19,7 @@
   "type": "module",
   "packageManager": "yarn@4.9.2",
   "engines": {
-    "node": "22",
+    "node": "20 || 22",
     "npm": "please-use-yarn",
     "yarn": "4.9.2"
   },


### PR DESCRIPTION
## Summary of Changes

This pull request updates the `package.json` file to reflect the new homepage URL, repository information, and node version compatibility for Sinan Bolel's personal website. These changes improve the project's metadata and ensure compatibility with multiple Node.js versions.

### Metadata updates:
* Updated the `homepage` field to use the new URL `https://sinanbolel.com` and changed the `bugs.url` to point to the new repository's issue tracker. Added the `repository` field with the new repository URL. (`[package.jsonL7-R13](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L7-R13)`)

### Node.js compatibility:
* Modified the `engines.node` field to specify compatibility with both Node.js versions 20 and 22. (`[package.jsonL18-R22](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L18-R22)`)