### PR TITLE
fix(home): restore hero heading contrast

### DIFF
--- a/src/views/Home/Home.tsx
+++ b/src/views/Home/Home.tsx
@@ -40,8 +40,8 @@ const Home: React.FC = () => {
       <Typography
         variant="h1"
         component="h1"
-        color="white"
         sx={{
+          color: (theme) => theme.palette.common.white,
           fontSize: '3rem',
           fontWeight: 300,
           marginBottom: '.5rem',
@@ -53,8 +53,8 @@ const Home: React.FC = () => {
       <Typography
         variant="h2"
         component="h2"
-        color="white"
         sx={{
+          color: (theme) => theme.palette.common.white,
           fontSize: '1.5rem',
           fontWeight: 200,
         }}


### PR DESCRIPTION
## Summary

Fixes the home hero heading contrast regression introduced after the dependency upgrade.

### Added

N/A

### Changed

- Uses the project theme to set the home page H1 and H2 text color to `theme.palette.common.white`.
- Removes the ineffective `color=\"white\"` Typography prop from the hero headings.

### Deprecated

N/A

### Removed

N/A

### Fixed

- Restores readability for the `Sinan Bolel` and `Principal Software Engineer` hero headings on the dark home page background.

## How to test

- `mise exec node@22 -- yarn jest --ci --coverage=false --colors --maxWorkers=50% src/views/Home/Home.test.tsx`
- `mise exec node@22 -- yarn build`
- `git diff --check`
- Playwright smoke against local Vite using `./.env`: confirmed H1 and H2 computed color is `rgb(255, 255, 255)`.