### PR TITLE
fix(seo): correct sitemap entries

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,38 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset
-      xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
-      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-      xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"
-      xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
-            http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd">
-<url>
-  <loc>https://sinanbolel.com</loc>
-  <lastmod>2025-05-26T14:00:00+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.9</priority>
-</url>
-<url>
-  <loc>https://sinanbolel.com/index.html</loc>
-  <lastmod>2025-05-26T14:00:00+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.1</priority>
-</url>
-<url>
-  <loc>https://sinanbolel.com/resume</loc>
-  <lastmod>2023-07-16T14:09:00+00:00</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>1.0</priority>
-</url>
-<url>
-  <loc>https://sinanbolel.com/resume.pdf</loc>
-  <lastmod>2023-07-16</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>0.5</priority>
-</url>
-<url>
-  <loc>https://sinanbolel.com/sinan-bolel-resume.pdf</loc>
-  <lastmod>2023-07-16</lastmod>
-  <changefreq>monthly</changefreq>
-  <priority>1.0</priority>
-</url>
+  xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:image="http://www.google.com/schemas/sitemap-image/1.1"
+  xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9
+        http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd"
+>
+  <url>
+    <loc>https://sinanbolel.com/</loc>
+    <lastmod>2026-05-14T06:54:28+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://sinanbolel.com/sinan-bolel-resume.pdf</loc>
+    <lastmod>2025-05-26T17:37:57+00:00</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary

Removes duplicate/non-canonical sitemap URLs.

### Added

None.

### Changed

- Sitemap now lists the canonical root URL and one canonical resume PDF URL.

### Deprecated

None.

### Removed

None.

### Fixed

- Removes `/index.html`, redirected `/resume`, and duplicate PDF entries.

## How to test

- `xmllint --noout public/sitemap.xml` - pass.
- `mise exec node@22 -- yarn install --immutable` - pass, with existing peer warnings.
- `mise exec node@22 -- yarn build` - pass, with existing Vite warnings.
- `git diff --check` - pass.