### PR TITLE
ci: add CodeQL workflow configuration

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,58 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: ["main"]
+    paths-ignore:
+      - "dist/**"
+      - "coverage/**"
+      - "node_modules/**"
+      - "**/*.min.js"
+
+  pull_request:
+    branches: ["main"]
+    paths-ignore:
+      - "dist/**"
+      - "coverage/**"
+      - "node_modules/**"
+      - "**/*.min.js"
+
+  schedule:
+    - cron: "29 17 * * 1" # Mondays at 17:29 UTC
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      security-events: write
+      packages: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: javascript-typescript
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: +security-extended,security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,24 +1,24 @@
-name: "CodeQL"
+name: 'CodeQL'
 
 on:
   push:
-    branches: ["main"]
+    branches: ['main']
     paths-ignore:
-      - "dist/**"
-      - "coverage/**"
-      - "node_modules/**"
-      - "**/*.min.js"
+      - 'dist/**'
+      - 'coverage/**'
+      - 'node_modules/**'
+      - '**/*.min.js'
 
   pull_request:
-    branches: ["main"]
+    branches: ['main']
     paths-ignore:
-      - "dist/**"
-      - "coverage/**"
-      - "node_modules/**"
-      - "**/*.min.js"
+      - 'dist/**'
+      - 'coverage/**'
+      - 'node_modules/**'
+      - '**/*.min.js'
 
   schedule:
-    - cron: "29 17 * * 1" # Mondays at 17:29 UTC
+    - cron: '29 17 * * 1' # Mondays at 17:29 UTC
 
 concurrency:
   group: codeql-${{ github.workflow }}-${{ github.ref }}
@@ -55,4 +55,4 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4
         with:
-          category: "/language:${{ matrix.language }}"
+          category: '/language:${{ matrix.language }}'


### PR DESCRIPTION
## Summary

Add a GitHub CodeQL workflow for this repository and configure it to run JavaScript/TypeScript analysis on pushes and pull requests targeting `main`, plus a weekly scheduled scan.

### Added

- A new `.github/workflows/codeql.yml` workflow that runs CodeQL analysis for `javascript-typescript`.
- CodeQL queries configured with `security-extended` and `security-and-quality`.
- A weekly scheduled scan on Mondays at 17:29 UTC.

### Changed

- Code scanning now runs on pull requests to `main` and pushes to `main`.
- Workflow triggers ignore generated or dependency-heavy paths such as `dist/**`, `coverage/**`, `node_modules/**`, and `**/*.min.js`.
- Concurrency is configured to cancel in-progress duplicate CodeQL runs for the same ref.

### Deprecated

- None.

### Removed

- None.

### Fixed

- Adds the missing repository CodeQL configuration so security analysis can run in GitHub Actions.

## How to test

1. Open this PR and confirm a `CodeQL` workflow run is triggered alongside the existing CI workflow.
2. In the Actions tab, verify the `Analyze (javascript-typescript)` job initializes CodeQL and completes analysis successfully.
3. Confirm the workflow is scoped to `main` for both `push` and `pull_request` events.
4. Confirm ignored paths are present in the workflow definition: `dist/**`, `coverage/**`, `node_modules/**`, and `**/*.min.js`.
