### PR TITLE
chore: add FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+github: sbolel
+buy_me_a_coffee: sbolel
+patreon: sbolel


### PR DESCRIPTION
## Summary

- Add `.github/FUNDING.yml` to enable repository funding links.
- Use funding config copied verbatim from `sbolel/sbolel`:
  - `github: sbolel`
  - `buy_me_a_coffee: sbolel`
  - `patreon: sbolel`

### Added
- New `.github/FUNDING.yml` file.

### Changed
- None

### Deprecated
- None

### Removed
- None

### Fixed
- None

## How to test

- Verify `.github/FUNDING.yml` content exactly matches the source.
