### PR TITLE
fix(ci): avoid Firestore emulator port conflicts

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test:precommit": "NODE_ENV=test jest --onlyChanged --coverage --colors --watch=false --maxWorkers=50%",
     "test:watch": "NODE_ENV=test jest --onlyChanged --coverage --colors --watch --maxWorkers=25%",
     "test:ci": "NODE_ENV=test jest --ci --all  --coverage --colors --maxWorkers=100%",
-    "test:firestore-rules": "firebase emulators:exec --config firebase.rules-test.json --only firestore \"node --test src/firebase/firestore.rules.test.mjs\"",
+    "test:firestore-rules": "node scripts/run-firestore-rules-tests.mjs",
     "ci": "run-p 'lint:js' 'lint:other' 'test:ci' 'test:firestore-rules'",
     "lint": "run-p 'lint:js' 'lint:other'",
     "lint:js": "prettier --check '**/*.{ts,tsx,js,jsx,cjs,mjs}' --ignore-path .gitignore --ignore-path .prettierignore",

--- a/scripts/run-firestore-rules-node-test.sh
+++ b/scripts/run-firestore-rules-node-test.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec mise exec node@22 -- node --test src/firebase/firestore.rules.test.mjs
+exec "${FIRESTORE_RULES_NODE_BINARY:-node}" --test src/firebase/firestore.rules.test.mjs

--- a/scripts/run-firestore-rules-node-test.sh
+++ b/scripts/run-firestore-rules-node-test.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec mise exec node@22 -- node --test src/firebase/firestore.rules.test.mjs

--- a/scripts/run-firestore-rules-tests.mjs
+++ b/scripts/run-firestore-rules-tests.mjs
@@ -52,7 +52,10 @@ const run = async () => {
         `firebase emulators:exec --config ${shellEscape(configPath)} --only firestore ${shellEscape(testCommand)}`,
         [],
         {
-          env: process.env,
+          env: {
+            ...process.env,
+            FIRESTORE_RULES_NODE_BINARY: process.execPath,
+          },
           shell: true,
           stdio: 'inherit',
         }

--- a/scripts/run-firestore-rules-tests.mjs
+++ b/scripts/run-firestore-rules-tests.mjs
@@ -1,0 +1,83 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { spawn } from 'node:child_process'
+import net from 'node:net'
+import os from 'node:os'
+import path from 'node:path'
+
+const firebaseConfig = JSON.parse(
+  readFileSync('firebase.rules-test.json', 'utf8')
+)
+const testCommand = './scripts/run-firestore-rules-node-test.sh'
+const shellEscape = (value) => `'${value.replaceAll("'", "'\\''")}'`
+
+const getAvailablePort = () =>
+  new Promise((resolve, reject) => {
+    const server = net.createServer()
+
+    server.unref()
+    server.on('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+
+      if (!address || typeof address === 'string') {
+        server.close(() =>
+          reject(new Error('Unable to allocate Firestore port'))
+        )
+        return
+      }
+
+      server.close((error) => {
+        if (error) {
+          reject(error)
+          return
+        }
+
+        resolve(address.port)
+      })
+    })
+  })
+
+const run = async () => {
+  const port = await getAvailablePort()
+  const tempDir = mkdtempSync(path.join(os.tmpdir(), 'firestore-rules-'))
+  const configPath = path.join(tempDir, 'firebase.rules-test.json')
+
+  firebaseConfig.emulators.firestore.port = port
+  firebaseConfig.firestore.rules = path.resolve(firebaseConfig.firestore.rules)
+  writeFileSync(configPath, `${JSON.stringify(firebaseConfig, null, 2)}\n`)
+
+  try {
+    const exitCode = await new Promise((resolve, reject) => {
+      const child = spawn(
+        `firebase emulators:exec --config ${shellEscape(configPath)} --only firestore ${shellEscape(testCommand)}`,
+        [],
+        {
+          env: process.env,
+          shell: true,
+          stdio: 'inherit',
+        }
+      )
+
+      child.on('error', reject)
+      child.on('exit', (code, signal) => {
+        if (signal) {
+          reject(
+            new Error(`Firestore rules test interrupted by signal ${signal}`)
+          )
+          return
+        }
+
+        resolve(code ?? 1)
+      })
+    })
+
+    process.exit(exitCode)
+  } finally {
+    rmSync(tempDir, { force: true, recursive: true })
+  }
+}
+
+run().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

Makes the Firestore rules test runner resilient to local port conflicts during `yarn ci` by allocating an open emulator port at runtime instead of assuming `8080` is available.

### Added

- `scripts/run-firestore-rules-tests.mjs` to allocate a temporary Firestore emulator port, write a temp Firebase config, and run the rules suite through `firebase emulators:exec`
- `scripts/run-firestore-rules-node-test.sh` as a stable executable wrapper for the Node test command

### Changed

- Updated `test:firestore-rules` in `package.json` to use the new dynamic-port runner

### Deprecated

None.

### Removed

None.

### Fixed

- Avoids local `yarn ci` failures when the Firestore emulator's default `8080` port is already in use
- Keeps the rules test pointed at the repo's real `firestore.rules` file even though the runtime config is generated in a temp directory

## How to test

- `mise exec node@22 -- node scripts/run-firestore-rules-tests.mjs`
- `mise exec node@22 -- yarn ci`

Validation notes:

- The dedicated Firestore rules command passed.
- `yarn ci` passed.
- Existing Jest console noise remains in the test output, but it did not fail the run.
