### PR TITLE
fix(accessibility): address Copilot follow-ups from #171

### DIFF
--- a/src/components/MultiDropzone/MultiDropzone.test.tsx
+++ b/src/components/MultiDropzone/MultiDropzone.test.tsx
@@ -75,6 +75,22 @@ test('calls onRemoveFile when a file is removed', () => {
   expect(handleRemoveFile).toHaveBeenCalledWith('1')
 })
 
+test('keeps the browse button keyboard reachable', () => {
+  render(
+    <MultiDropzone
+      onFileSelect={() => ({})}
+      onRemoveFile={() => ({})}
+      uploadedFiles={[]}
+      uploading={false}
+    />
+  )
+
+  const browseButton = screen.getByRole('button', { name: /browse for files/i })
+
+  expect(browseButton).not.toHaveAttribute('tabindex', '-1')
+  expect(browseButton.tabIndex).toBe(0)
+})
+
 test('displays uploaded files', () => {
   render(
     <MultiDropzone

--- a/src/components/MultiDropzone/MultiDropzone.tsx
+++ b/src/components/MultiDropzone/MultiDropzone.tsx
@@ -94,7 +94,6 @@ const DefaultCTA: React.FC = (): React.JSX.Element => (
       aria-label="Browse for Files"
       color="primary"
       size="small"
-      tabIndex={-1}
       sx={{
         p: 0,
         lineHeight: 2,

--- a/src/components/crud/CreateForm.test.tsx
+++ b/src/components/crud/CreateForm.test.tsx
@@ -4,6 +4,7 @@ import {
   fireEvent,
   render,
   renderHook,
+  screen,
   waitFor,
 } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -56,6 +57,13 @@ test('renders the form when open is true', async () => {
   const addressField = getByLabelText(/Address/)
   expect(nameField).toBeInTheDocument()
   expect(addressField).toBeInTheDocument()
+  expect(
+    screen.getByText('Complete the required fields and submit the form.')
+  ).toHaveAttribute('id', 'create-form-description')
+  expect(screen.getByRole('dialog')).toHaveAttribute(
+    'aria-describedby',
+    'create-form-description'
+  )
 })
 
 test('calls onSubmit with form data when form is submitted', async () => {

--- a/src/components/crud/CreateForm.tsx
+++ b/src/components/crud/CreateForm.tsx
@@ -112,10 +112,10 @@ const CreateForm: React.FC<CreateFormProps> = ({
           id={descriptionId}
           sx={{
             position: 'absolute',
-            width: 1,
-            height: 1,
+            width: '1px',
+            height: '1px',
             p: 0,
-            m: -1,
+            m: '-1px',
             overflow: 'hidden',
             clip: 'rect(0, 0, 0, 0)',
             whiteSpace: 'nowrap',

--- a/src/components/crud/CreateForm.tsx
+++ b/src/components/crud/CreateForm.tsx
@@ -54,6 +54,7 @@ const CreateForm: React.FC<CreateFormProps> = ({
   DialogProps,
   FormProps,
 }): React.JSX.Element => {
+  const descriptionText = 'Complete the required fields and submit the form.'
   const {
     control,
     register,
@@ -107,6 +108,22 @@ const CreateForm: React.FC<CreateFormProps> = ({
         {title || 'Create New'}
       </DialogTitle>
       <DialogContent>
+        <Box
+          id={descriptionId}
+          sx={{
+            position: 'absolute',
+            width: 1,
+            height: 1,
+            p: 0,
+            m: -1,
+            overflow: 'hidden',
+            clip: 'rect(0, 0, 0, 0)',
+            whiteSpace: 'nowrap',
+            border: 0,
+          }}
+        >
+          {descriptionText}
+        </Box>
         <Box
           component="form"
           onSubmit={handleSubmit(onSubmit)}

--- a/src/hooks/useDialog.test.tsx
+++ b/src/hooks/useDialog.test.tsx
@@ -3,7 +3,12 @@ import DialogProvider, { useDialog } from '@/hooks/useDialog'
 import React from 'react'
 
 jest.mock('@mui/material/Dialog', () => (props: any) => (
-  <div data-testid="dialog" data-open={String(props.open)}>
+  <div
+    data-testid="dialog"
+    data-open={String(props.open)}
+    aria-labelledby={props['aria-labelledby']}
+    aria-describedby={props['aria-describedby']}
+  >
     {props.open ? props.children : null}
   </div>
 ))
@@ -46,5 +51,35 @@ describe('useDialog', () => {
     })
     expect(screen.getByTestId('dialog')).toHaveAttribute('data-open', 'true')
     expect(screen.getByTestId('dialog').textContent).toBe('text')
+  })
+
+  test('does not emit fallback aria ids when none are provided', () => {
+    const { result } = renderHook(() => useDialog(), { wrapper })
+    act(() => {
+      result.current[0]({ children: <div>child</div> })
+    })
+    expect(screen.getByTestId('dialog')).not.toHaveAttribute('aria-labelledby')
+    expect(screen.getByTestId('dialog')).not.toHaveAttribute('aria-describedby')
+  })
+
+  test('passes through explicit aria ids from dialog props', () => {
+    const { result } = renderHook(() => useDialog(), { wrapper })
+    act(() => {
+      result.current[0]({
+        children: <div>child</div>,
+        props: {
+          'aria-labelledby': 'custom-title',
+          'aria-describedby': 'custom-description',
+        },
+      })
+    })
+    expect(screen.getByTestId('dialog')).toHaveAttribute(
+      'aria-labelledby',
+      'custom-title'
+    )
+    expect(screen.getByTestId('dialog')).toHaveAttribute(
+      'aria-describedby',
+      'custom-description'
+    )
   })
 })

--- a/src/hooks/useDialog.tsx
+++ b/src/hooks/useDialog.tsx
@@ -87,10 +87,8 @@ const DialogProvider: React.FC<React.PropsWithChildren> = ({
         {...dialogProps}
         onClose={closeDialog}
         open={open}
-        aria-labelledby={dialogProps?.['aria-labelledby'] || 'dialog-title'}
-        aria-describedby={
-          dialogProps?.['aria-describedby'] || 'dialog-description'
-        }
+        aria-labelledby={dialogProps?.['aria-labelledby']}
+        aria-describedby={dialogProps?.['aria-describedby']}
         keepMounted={false}
       >
         {Children.map(dialogChildren, (child) => {


### PR DESCRIPTION
## Summary

Follow-up accessibility fixes from merged PR #171.

### Added

- Hidden dialog description content for `CreateForm` so `aria-describedby="create-form-description"` points to a real element.
- Targeted regression coverage for `CreateForm`, `useDialog`, and `MultiDropzone`.

### Changed

- `useDialog` now passes `aria-labelledby` and `aria-describedby` through only when callers provide them.
- `MultiDropzone` keeps the `Browse for Files` button keyboard reachable.

### Deprecated

- None.

### Removed

- The keyboard-blocking `tabIndex={-1}` override on the browse button.

### Fixed

- Copilot follow-up accessibility issues called out after PR #171 merged.
- The carry-forward dialog prop compatibility issue previously fixed on the old branch.

## How to test

- `env NODE_ENV=test mise exec node@22.22.3 -- yarn exec jest --config jest.config.cjs --runInBand src/components/crud/CreateForm.test.tsx`
- `env NODE_ENV=test mise exec node@22.22.3 -- yarn exec jest --config jest.config.cjs --runInBand src/hooks/useDialog.test.tsx`
- `env NODE_ENV=test mise exec node@22.22.3 -- yarn exec jest --config jest.config.cjs --runInBand src/components/MultiDropzone/MultiDropzone.test.tsx`
- `mise exec node@22.22.3 -- yarn build`
- `mise exec node@22.22.3 -- yarn ci`
