### PR TITLE
fix(app): route-protect /app and share chat context

### DIFF
--- a/src/Root.tsx
+++ b/src/Root.tsx
@@ -4,6 +4,7 @@
  */
 import { Outlet } from 'react-router-dom'
 import { ThemeProvider } from '@mui/material/styles'
+import { ChatProvider } from '@/contexts/ChatContext'
 import { AlertProvider } from '@/hooks/useAlert'
 import DialogProvider from '@/hooks/useDialog'
 import AuthProvider from '@/store/auth/AuthProvider'
@@ -12,11 +13,13 @@ import theme from '@/theme/theme'
 const Root: React.FC = () => (
   <ThemeProvider theme={theme}>
     <AuthProvider>
-      <AlertProvider>
-        <DialogProvider>
-          <Outlet />
-        </DialogProvider>
-      </AlertProvider>
+      <ChatProvider>
+        <AlertProvider>
+          <DialogProvider>
+            <Outlet />
+          </DialogProvider>
+        </AlertProvider>
+      </ChatProvider>
     </AuthProvider>
   </ThemeProvider>
 )

--- a/src/contexts/ChatContext.Root.test.tsx
+++ b/src/contexts/ChatContext.Root.test.tsx
@@ -1,0 +1,53 @@
+import React, { useContext } from 'react'
+import { render, screen } from '@testing-library/react'
+import Root from '@/Root'
+import { ChatContext } from './ChatContext'
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom')
+
+  return {
+    ...actual,
+    Outlet: () => {
+      const { state } = useContext(ChatContext)
+
+      return (
+        <div data-testid="chat-context-state">
+          {JSON.stringify({
+            chatId: state.chatId,
+            messages: state.messages.length,
+            showCaption: state.showCaption,
+          })}
+        </div>
+      )
+    },
+  }
+})
+
+jest.mock('@/store/auth/AuthProvider', () => ({
+  __esModule: true,
+  default: ({ children }: React.PropsWithChildren) => <>{children}</>,
+}))
+
+jest.mock('@/hooks/useAlert', () => ({
+  AlertProvider: ({ children }: React.PropsWithChildren) => <>{children}</>,
+}))
+
+jest.mock('@/hooks/useDialog', () => ({
+  __esModule: true,
+  default: ({ children }: React.PropsWithChildren) => <>{children}</>,
+}))
+
+describe('Root chat provider wiring', () => {
+  test('provides chat context to routed children', () => {
+    render(<Root />)
+
+    expect(screen.getByTestId('chat-context-state')).toHaveTextContent(
+      JSON.stringify({
+        chatId: null,
+        messages: 0,
+        showCaption: false,
+      })
+    )
+  })
+})

--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -1,6 +1,5 @@
 import React, { createContext, useReducer } from 'react'
 import { Message } from '@/types/chat'
-import { AuthProviderProps } from '@/store/auth/types'
 
 export interface ChatState {
   messages: Message[]
@@ -48,7 +47,9 @@ export const ChatContext = createContext<ChatContextProps>({
   dispatch: () => null,
 })
 
-export const ChatProvider: React.FC<AuthProviderProps> = ({ children }) => {
+type ChatProviderProps = React.PropsWithChildren
+
+export const ChatProvider: React.FC<ChatProviderProps> = ({ children }) => {
   const [state, dispatch] = useReducer(chatReducer, initialState)
 
   return (

--- a/src/layouts/AppLayout/AppLayout.test.tsx
+++ b/src/layouts/AppLayout/AppLayout.test.tsx
@@ -9,12 +9,16 @@ jest.mock('react-router-dom', () => ({
 }))
 
 beforeEach(() => {
-  ;(useLoaderData as jest.Mock).mockReturnValue('jwt-token')
+  ;(useLoaderData as jest.Mock).mockReturnValue({ jwtToken: 'jwt-token' })
 })
 
 test('renders the main application layout', () => {
   render(<AppLayout />, { wrapper: (props) => <BrowserRouter {...props} /> })
 
+  expect(screen.getByTestId('app')).toHaveAttribute(
+    'data-jwt-token',
+    'jwt-token'
+  )
   expect(screen.getByTestId('appbar-title')).toHaveTextContent(DASHBOARD_TITLE)
   expect(screen.getByRole('button', { name: /login/i })).toBeInTheDocument()
 })

--- a/src/layouts/AppLayout/AppLayout.tsx
+++ b/src/layouts/AppLayout/AppLayout.tsx
@@ -3,7 +3,7 @@
  * @module layouts/AppLayout/AppLayout
  */
 import { useCallback, useState, Suspense, useRef, useEffect } from 'react'
-import { Await, Navigate, Outlet, useLoaderData } from 'react-router-dom'
+import { Outlet, useLoaderData } from 'react-router-dom'
 import CssBaseline from '@mui/material/CssBaseline'
 import Box from '@mui/material/Box'
 import Container from '@mui/material/Container'
@@ -28,7 +28,7 @@ import AuthButton from '@/components/HeaderAuthButton'
 import MenuListItems from '@/layouts/AppLayout/AppDrawerButtonList'
 import Chat from '@/components/Chat/Chat'
 import { DASHBOARD_TITLE } from '@/locales/en'
-import { Routes } from '@/router/constants'
+import type { AuthLoaderData } from '@/router/authLoader'
 
 /**
  * The main layout that renders the application layout for authenticated users.
@@ -36,7 +36,7 @@ import { Routes } from '@/router/constants'
  * @returns {React.JSX.Element} The main application layout component.
  */
 const AppLayout: React.FC = (): React.JSX.Element => {
-  const jwtToken = useLoaderData() as string
+  const { jwtToken } = useLoaderData() as AuthLoaderData
   const [drawerOpen, setDrawerOpen] = useState(true)
   const [chatOpen, setChatOpen] = useState(false)
 
@@ -84,168 +84,157 @@ const AppLayout: React.FC = (): React.JSX.Element => {
   return (
     <>
       <CssBaseline />
-      <Suspense
-        fallback={
-          <Navigate
-            to={Routes.AUTH_LOGIN}
-            state={{ from: window.location.pathname }}
-            replace
-          />
-        }
+      <Box
+        data-testid="app"
+        data-jwt-token={jwtToken}
+        sx={{
+          display: 'flex',
+          flexGrow: 1,
+          height: '100vh',
+          overflow: 'scroll',
+        }}
       >
-        <Await resolve={jwtToken}>
-          <Box
-            data-testid="app"
+        <AlertMessage />
+
+        {/* top nav bar */}
+        <AppBar position="absolute" open={drawerOpen} color="secondary">
+          <Toolbar>
+            <IconButton
+              edge="start"
+              color="inherit"
+              onClick={toggleDrawer}
+              sx={{
+                marginRight: '36px',
+                ...(drawerOpen && { display: 'none' }),
+              }}
+              aria-label="open drawer"
+              data-testid="open-drawer-button"
+              name="open drawer"
+              aria-hidden={drawerOpen}
+            >
+              <MenuIcon />
+            </IconButton>
+            <Typography
+              color="inherit"
+              component="span"
+              noWrap
+              sx={{ flexGrow: 1 }}
+              variant="h6"
+              data-testid="appbar-title"
+            >
+              {DASHBOARD_TITLE}
+            </Typography>
+            <AuthButton />
+          </Toolbar>
+        </AppBar>
+
+        {/* menu drawer */}
+        <AppDrawer
+          open={drawerOpen}
+          data-open={drawerOpen}
+          data-testid="app-drawer"
+        >
+          <Toolbar
             sx={{
               display: 'flex',
-              flexGrow: 1,
-              height: '100vh',
-              overflow: 'scroll',
+              alignItems: 'center',
+              justifyContent: 'flex-end',
+              filter: `brightness(80%)`,
             }}
           >
-            <AlertMessage />
+            <IconButton
+              onClick={toggleDrawer}
+              aria-label="close drawer"
+              data-testid="close-drawer-button"
+              name="close drawer"
+              aria-hidden={!drawerOpen}
+            >
+              <ChevronLeftIcon />
+            </IconButton>
+          </Toolbar>
+          <Divider />
 
-            {/* top nav bar */}
-            <AppBar position="absolute" open={drawerOpen} color="secondary">
-              <Toolbar>
-                <IconButton
-                  edge="start"
-                  color="inherit"
-                  onClick={toggleDrawer}
-                  sx={{
-                    marginRight: '36px',
-                    ...(drawerOpen && { display: 'none' }),
-                  }}
-                  aria-label="open drawer"
-                  data-testid="open-drawer-button"
-                  name="open drawer"
-                  aria-hidden={drawerOpen}
-                >
-                  <MenuIcon />
-                </IconButton>
-                <Typography
-                  color="inherit"
-                  component="span"
-                  noWrap
-                  sx={{ flexGrow: 1 }}
-                  variant="h6"
-                  data-testid="appbar-title"
-                >
-                  {DASHBOARD_TITLE}
-                </Typography>
-                <AuthButton />
-              </Toolbar>
-            </AppBar>
-
-            {/* menu drawer */}
-            <AppDrawer
-              open={drawerOpen}
-              data-open={drawerOpen}
-              data-testid="app-drawer"
-            >
-              <Toolbar
-                sx={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'flex-end',
-                  filter: `brightness(80%)`,
-                }}
-              >
-                <IconButton
-                  onClick={toggleDrawer}
-                  aria-label="close drawer"
-                  data-testid="close-drawer-button"
-                  name="close drawer"
-                  aria-hidden={!drawerOpen}
-                >
-                  <ChevronLeftIcon />
-                </IconButton>
-              </Toolbar>
-              <Divider />
-
-              <List component="nav">
-                <MenuListItems />
-              </List>
-            </AppDrawer>
-            <Container
-              component="main"
-              sx={{
-                mt: (theme) => `${theme.mixins.toolbar.minHeight}px`,
-                pt: (theme) => theme.spacing(4),
-              }}
-            >
-              {/* Skip to main content link */}
-              <Box
-                component="a"
-                href="#main-content"
-                sx={{
-                  position: 'absolute',
-                  left: '-9999px',
-                  top: 'auto',
-                  width: '1px',
-                  height: '1px',
-                  overflow: 'hidden',
-                  '&:focus': {
-                    position: 'static',
-                    width: 'auto',
-                    height: 'auto',
-                    overflow: 'visible',
-                    left: 0,
-                    top: 0,
-                    backgroundColor: 'primary.main',
-                    color: 'primary.contrastText',
-                    padding: 1,
-                    textDecoration: 'none',
-                    zIndex: 9999,
-                  },
-                }}
-              >
-                Skip to main content
-              </Box>
-              <Box id="main-content" tabIndex={-1}>
-                <Outlet />
-              </Box>
-            </Container>
-            <Tooltip
-              title="Let's chat"
-              open={!chatClicked}
-              disableHoverListener={chatClicked}
-              placement="left"
-            >
-              <Fab
-                ref={chatButtonRef}
-                color="primary"
-                aria-label={chatOpen ? 'close chat' : 'open chat'}
-                aria-expanded={chatOpen}
-                aria-controls="chat-dialog"
-                sx={{
-                  position: 'fixed',
-                  bottom: 16,
-                  right: 16,
-                }}
-                onClick={toggleChat}
-              >
-                {chatOpen ? <CloseIcon /> : <ChatIcon />}
-              </Fab>
-            </Tooltip>
-            <Dialog
-              open={chatOpen}
-              onClose={toggleChat}
-              aria-labelledby="chat-dialog-title"
-              aria-describedby="chat-dialog-description"
-              maxWidth="sm"
-              fullWidth
-              id="chat-dialog"
-            >
-              <DialogContent>
-                <Suspense fallback={<CircularProgress />}>
-                  <Chat />
-                </Suspense>
-              </DialogContent>
-            </Dialog>
+          <List component="nav">
+            <MenuListItems />
+          </List>
+        </AppDrawer>
+        <Container
+          component="main"
+          sx={{
+            mt: (theme) => `${theme.mixins.toolbar.minHeight}px`,
+            pt: (theme) => theme.spacing(4),
+          }}
+        >
+          {/* Skip to main content link */}
+          <Box
+            component="a"
+            href="#main-content"
+            sx={{
+              position: 'absolute',
+              left: '-9999px',
+              top: 'auto',
+              width: '1px',
+              height: '1px',
+              overflow: 'hidden',
+              '&:focus': {
+                position: 'static',
+                width: 'auto',
+                height: 'auto',
+                overflow: 'visible',
+                left: 0,
+                top: 0,
+                backgroundColor: 'primary.main',
+                color: 'primary.contrastText',
+                padding: 1,
+                textDecoration: 'none',
+                zIndex: 9999,
+              },
+            }}
+          >
+            Skip to main content
           </Box>
-        </Await>
-      </Suspense>
+          <Box id="main-content" tabIndex={-1}>
+            <Outlet />
+          </Box>
+        </Container>
+        <Tooltip
+          title="Let's chat"
+          open={!chatClicked}
+          disableHoverListener={chatClicked}
+          placement="left"
+        >
+          <Fab
+            ref={chatButtonRef}
+            color="primary"
+            aria-label={chatOpen ? 'close chat' : 'open chat'}
+            aria-expanded={chatOpen}
+            aria-controls="chat-dialog"
+            sx={{
+              position: 'fixed',
+              bottom: 16,
+              right: 16,
+            }}
+            onClick={toggleChat}
+          >
+            {chatOpen ? <CloseIcon /> : <ChatIcon />}
+          </Fab>
+        </Tooltip>
+        <Dialog
+          open={chatOpen}
+          onClose={toggleChat}
+          aria-labelledby="chat-dialog-title"
+          aria-describedby="chat-dialog-description"
+          maxWidth="sm"
+          fullWidth
+          id="chat-dialog"
+        >
+          <DialogContent>
+            <Suspense fallback={<CircularProgress />}>
+              <Chat />
+            </Suspense>
+          </DialogContent>
+        </Dialog>
+      </Box>
     </>
   )
 }

--- a/src/router/authLoader.ts
+++ b/src/router/authLoader.ts
@@ -3,10 +3,26 @@
  * @module router/authLoader
  * @see {@link dashboard/Routes}
  */
+import { redirect } from 'react-router-dom'
 import getJWT from '@/utils/getJWT'
+import { Routes } from '@/router/constants'
 
-const authLoader = async (): Promise<unknown> => ({
-  jwtToken: getJWT(),
-})
+export interface AuthLoaderData {
+  jwtToken: string
+}
+
+const authLoader = async (): Promise<AuthLoaderData> => {
+  try {
+    const jwtToken = await getJWT()
+
+    return { jwtToken }
+  } catch (error) {
+    if (error instanceof Response && [401, 403].includes(error.status)) {
+      throw redirect(Routes.AUTH_LOGIN)
+    }
+
+    throw error
+  }
+}
 
 export default authLoader

--- a/src/router/router.test.ts
+++ b/src/router/router.test.ts
@@ -1,12 +1,18 @@
+import { redirect } from 'react-router-dom'
 import router from './router'
+import authLoader from './authLoader'
 import { RouteIds, Routes } from './constants'
+import getJWT from '@/utils/getJWT'
 
-jest.mock('aws-amplify/auth', () => ({
-  fetchAuthSession: jest.fn(),
-  getCurrentUser: jest.fn(),
-}))
+jest.mock('@/utils/getJWT', () => jest.fn())
+
+const mockGetJWT = getJWT as jest.MockedFunction<typeof getJWT>
 
 describe('router configuration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
   test('includes expected paths', () => {
     const collectPaths = (routes: any[]): string[] =>
       routes.reduce((acc: string[], route) => {
@@ -28,5 +34,19 @@ describe('router configuration', () => {
     )
     const rootRoute = router.routes.find((r) => r.id === RouteIds.ROOT)
     expect(rootRoute).toBeTruthy()
+  })
+
+  test('authLoader resolves typed auth data for protected routes', async () => {
+    mockGetJWT.mockResolvedValue('jwt-token')
+
+    await expect(authLoader()).resolves.toEqual({ jwtToken: 'jwt-token' })
+  })
+
+  test(`authLoader redirects unauthenticated users to ${Routes.AUTH_LOGIN}`, async () => {
+    const unauthorized = new Response(null, { status: 401 })
+
+    mockGetJWT.mockRejectedValue(unauthorized)
+
+    await expect(authLoader()).rejects.toEqual(redirect(Routes.AUTH_LOGIN))
   })
 })

--- a/src/store/auth/AuthProvider.test.tsx
+++ b/src/store/auth/AuthProvider.test.tsx
@@ -1,23 +1,33 @@
+import { useContext } from 'react'
 import { screen, render, act, waitFor } from '@testing-library/react'
-import { useLocation, useMatch, useNavigate } from 'react-router-dom'
 import { fetchAuthSession, getCurrentUser } from 'aws-amplify/auth'
-import { AuthActions } from '@/actions/actionTypes'
 import AuthProvider from '@/store/auth/AuthProvider'
-import AuthDispatchContext from '@/store/auth/AuthDispatchContext'
 import AuthStateContext from '@/store/auth/AuthStateContext'
-import { Routes } from '@/router/constants'
+
+const AuthStateProbe = () => {
+  const authState = useContext(AuthStateContext)
+
+  return (
+    <>
+      <div data-testid="jwt-token">{authState.jwtToken ?? ''}</div>
+      <div data-testid="auth-error">{authState.error?.message ?? ''}</div>
+    </>
+  )
+}
 
 const Content = () => (
   <AuthProvider>
     <div>Child component</div>
+    <AuthStateProbe />
   </AuthProvider>
 )
 
-jest.mock('react-router-dom', () => ({
-  useLocation: jest.fn(),
-  useMatch: jest.fn(),
-  useNavigate: jest.fn(),
-}))
+const flushEffects = async () => {
+  await act(async () => {
+    await Promise.resolve()
+  })
+}
+
 jest.mock('aws-amplify/auth', () => ({
   fetchAuthSession: jest.fn(),
   getCurrentUser: jest.fn(),
@@ -39,22 +49,8 @@ const mockSession = (jwtToken: string) => ({
 })
 
 describe('AuthProvider', () => {
-  let mockDispatch: jest.Mock
-  let mockNavigate: jest.Mock
-  let mockUseLocation: jest.Mock
-  let mockUseMatch: jest.Mock
-  let mockUseNavigate: jest.Mock
-
   beforeEach(() => {
     jest.clearAllMocks()
-    mockDispatch = jest.fn()
-    mockNavigate = jest.fn()
-    mockUseLocation = useLocation as jest.Mock
-    mockUseMatch = useMatch as jest.Mock
-    mockUseNavigate = useNavigate as jest.Mock
-    mockUseNavigate.mockReturnValue(mockNavigate)
-    mockUseLocation.mockReturnValue({ pathname: Routes.AUTH_LOGIN })
-    mockUseMatch.mockReturnValue(null)
     mockGetCurrentUser.mockResolvedValue({
       username: 'test',
       userId: 'test',
@@ -63,167 +59,57 @@ describe('AuthProvider', () => {
   })
 
   test('renders the children', async () => {
-    await act(async () => {
-      render(<Content />)
-    })
+    render(<Content />)
+    await flushEffects()
     expect(screen.getByText('Child component')).toBeInTheDocument()
-    expect(mockUseLocation).toHaveBeenCalled()
-    expect(mockUseMatch).toHaveBeenCalled()
-    expect(mockUseNavigate).toHaveBeenCalled()
   })
 
   test('initializes the AuthContext on mount', async () => {
-    const mockLocation = { pathname: Routes.AUTH_LOGIN }
-    const mockMatch = { path: Routes.DASHBOARD }
-    const mockState = { jwtToken: 'mockJwtToken' }
+    render(<Content />)
+    await flushEffects()
 
-    mockUseLocation.mockReturnValue(mockLocation)
-    mockUseMatch.mockReturnValue(mockMatch)
-
-    await act(async () => {
-      render(
-        <AuthStateContext.Provider value={mockState}>
-          <AuthDispatchContext.Provider value={mockDispatch}>
-            <Content />
-          </AuthDispatchContext.Provider>
-        </AuthStateContext.Provider>
-      )
-    })
-
-    waitFor(() => {
-      expect(mockDispatch).toHaveBeenCalledTimes(1)
-      expect(mockDispatch).toHaveBeenCalledWith({
-        type: AuthActions.LOGIN_SUCCESS,
-        payload: structuredClone(mockState),
+    await waitFor(() => {
+      expect(mockGetCurrentUser).toHaveBeenCalledTimes(1)
+      expect(mockFetchAuthSession).toHaveBeenCalledTimes(2)
+      expect(mockFetchAuthSession).toHaveBeenNthCalledWith(2, {
+        forceRefresh: true,
       })
-      expect(mockNavigate).not.toHaveBeenCalled()
     })
   })
 
   test('handles initialization error', async () => {
-    const mockLocation = { pathname: Routes.DASHBOARD }
-    const mockMatch = { path: Routes.DASHBOARD }
-    const mockState = { jwtToken: 'test' }
     const mockError = new Error('Initialization error')
+    mockGetCurrentUser.mockRejectedValue(mockError)
 
-    mockUseLocation.mockReturnValue(mockLocation)
-    mockUseMatch.mockReturnValue(mockMatch)
+    render(<Content />)
+    await flushEffects()
 
-    await act(async () => {
-      render(
-        <AuthStateContext.Provider value={mockState}>
-          <AuthDispatchContext.Provider value={mockDispatch}>
-            <Content />
-          </AuthDispatchContext.Provider>
-        </AuthStateContext.Provider>
-      )
-    })
-
-    waitFor(() => {
-      expect(mockUseLocation).toHaveBeenCalled()
-      expect(mockUseMatch).toHaveBeenCalled()
-      expect(mockUseNavigate).toHaveBeenCalled()
-      expect(mockGetCurrentUser).toHaveBeenCalled()
-      expect(mockFetchAuthSession).toHaveBeenCalled()
-      expect(mockDispatch).toHaveBeenCalledTimes(1)
-      expect(mockDispatch).toHaveBeenCalledWith({
-        type: AuthActions.LOGIN_FAILURE,
-        error: mockError,
-      })
-      expect(mockNavigate).toHaveBeenCalledWith(Routes.AUTH_LOGIN)
-    })
+    expect(mockGetCurrentUser).toHaveBeenCalled()
+    expect(mockFetchAuthSession).toHaveBeenCalledTimes(1)
+    expect(screen.getByTestId('auth-error')).toHaveTextContent(
+      'Initialization error'
+    )
   })
 
-  test(`redirects to ${Routes.DASHBOARD} when user is authenticated and on ${Routes.AUTH_LOGIN}`, async () => {
-    const mockLocation = { pathname: Routes.AUTH_LOGIN }
-    const mockMatch = null
-    const mockState = { jwtToken: 'test' }
+  test('dispatches login success with the refreshed jwt token when one is returned', async () => {
+    const accessToken = { toString: () => 'staleJwtToken' }
+    const refreshedAccessToken = { toString: () => 'freshJwtToken' }
+    mockFetchAuthSession
+      .mockResolvedValueOnce({
+        tokens: {
+          accessToken,
+        },
+      } as never)
+      .mockResolvedValueOnce({
+        tokens: {
+          accessToken: refreshedAccessToken,
+        },
+      } as never)
+    render(<Content />)
+    await flushEffects()
 
-    mockUseLocation.mockReturnValue(mockLocation)
-    mockUseMatch.mockReturnValue(mockMatch)
-
-    mockGetCurrentUser.mockResolvedValue({
-      username: 'test',
-      userId: 'test',
-    })
-    mockFetchAuthSession.mockResolvedValue(mockSession('123456'))
-
-    await act(async () => {
-      render(
-        <AuthStateContext.Provider value={mockState}>
-          <AuthDispatchContext.Provider value={mockDispatch}>
-            <Content />
-          </AuthDispatchContext.Provider>
-        </AuthStateContext.Provider>
-      )
-    })
-
-    waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith(Routes.DASHBOARD)
-    })
-  })
-
-  test(`redirects to ${Routes.AUTH_LOGIN} when user is not authenticated and on protected route`, async () => {
-    const mockLocation = { pathname: Routes.DASHBOARD }
-    const mockMatch = { path: Routes.DASHBOARD }
-
-    mockUseLocation.mockReturnValue(mockLocation)
-    mockUseMatch.mockReturnValue(mockMatch)
-
-    mockGetCurrentUser.mockRejectedValue(new Error('No user or session'))
-
-    act(() => {
-      render(
-        <AuthDispatchContext.Provider value={mockDispatch}>
-          <Content />
-        </AuthDispatchContext.Provider>
-      )
-    })
-
-    waitFor(() => {
-      expect(mockNavigate).toHaveBeenCalledWith(Routes.AUTH_LOGIN)
-    })
-  })
-
-  test(`redirects to ${Routes.AUTH_LOGIN} if the current session does not get a valid jwtToken`, async () => {
-    mockFetchAuthSession.mockResolvedValue(mockSession(''))
-
-    mockUseLocation.mockReturnValue({ pathname: Routes.DASHBOARD })
-    mockUseMatch.mockReturnValue({ path: Routes.DASHBOARD })
-
-    await act(async () => {
-      render(
-        <AuthDispatchContext.Provider value={mockDispatch}>
-          <Content />
-        </AuthDispatchContext.Provider>
-      )
-    })
-
-    waitFor(() => {
-      expect(mockDispatch).toHaveBeenCalledTimes(1)
-      expect(mockDispatch).toHaveBeenCalledWith({
-        type: AuthActions.LOGIN_FAILURE,
-        error: new Error('Initialization error'),
-      })
-      expect(mockNavigate).toHaveBeenCalledWith(Routes.AUTH_LOGIN)
-    })
-  })
-
-  test(`does not redirect when user is not authenticated and on ${Routes.AUTH_LOGIN}`, async () => {
-    mockUseLocation.mockReturnValue({ pathname: Routes.AUTH_LOGIN })
-    mockUseMatch.mockReturnValue(null)
-
-    await act(async () => {
-      render(
-        <AuthDispatchContext.Provider value={mockDispatch}>
-          <Content />
-        </AuthDispatchContext.Provider>
-      )
-    })
-
-    waitFor(() => {
-      expect(mockDispatch).toHaveBeenCalledTimes(2)
-      expect(mockNavigate).not.toHaveBeenCalled()
+    await waitFor(() => {
+      expect(screen.getByTestId('jwt-token')).toHaveTextContent('freshJwtToken')
     })
   })
 })

--- a/src/store/auth/AuthProvider.tsx
+++ b/src/store/auth/AuthProvider.tsx
@@ -4,14 +4,12 @@
 import { fetchAuthSession, getCurrentUser } from 'aws-amplify/auth'
 import type { AuthSession } from 'aws-amplify/auth'
 import { useCallback, useEffect, useReducer } from 'react'
-import { useLocation, useMatch, useNavigate } from 'react-router-dom'
 import { AuthActions } from '@/actions/actionTypes'
 import AuthReducer from '@/store/auth/AuthReducer'
 import { AuthProviderProps } from '@/store/auth/types'
 import { INITIAL_STATE } from '@/store/auth/constants'
 import AuthDispatchContext from '@/store/auth/AuthDispatchContext'
 import AuthStateContext from '@/store/auth/AuthStateContext'
-import { Routes } from '@/router/constants'
 
 /**
  * The AuthContextProvider is used to provide user data to components.
@@ -22,9 +20,6 @@ import { Routes } from '@/router/constants'
 const AuthProvider: React.FC<AuthProviderProps> = ({
   children,
 }): React.JSX.Element => {
-  const location = useLocation()
-  const navigate = useNavigate()
-  const matchProtectedRoute = useMatch('/app/*')
   const [user, dispatch] = useReducer(AuthReducer, { ...INITIAL_STATE })
 
   /**
@@ -61,24 +56,13 @@ const AuthProvider: React.FC<AuthProviderProps> = ({
           jwtToken: refreshedJwtToken ?? jwtToken,
         },
       })
-
-      // if the unauthenticated user is trying to navigate to a
-      // protected app routue, redirect them to the login page.
-      if (!matchProtectedRoute && location.pathname !== Routes.AUTH_LOGOUT) {
-        // navigate(Routes.DASHBOARD)
-      }
     } catch (error) {
       dispatch({
         type: AuthActions.LOGIN_FAILURE,
         error: error as Error,
       })
-      // if the unauthenticated user is trying to navigate to a
-      // protected app routue, redirect them to the login page.
-      if (matchProtectedRoute) {
-        // navigate(Routes.AUTH_LOGIN)
-      }
     }
-  }, [location?.pathname, matchProtectedRoute, navigate, dispatch])
+  }, [dispatch])
 
   /**
    * Effect that initializes the AuthContext by checking for a user session

--- a/src/views/Home/Home.test.tsx
+++ b/src/views/Home/Home.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import Home from './Home'
+import { ChatProvider } from '@/contexts/ChatContext'
 
 jest.mock('@/components/Chat/Chat', () => () => (
   <div data-testid="chat-component">Chat</div>
@@ -7,7 +8,11 @@ jest.mock('@/components/Chat/Chat', () => () => (
 jest.mock('@/views/Home/Home.module.scss', () => ({}), { virtual: true })
 
 test('toggles chat dialog when button is clicked', async () => {
-  render(<Home />)
+  render(
+    <ChatProvider>
+      <Home />
+    </ChatProvider>
+  )
   const button = screen.getByRole('button', { name: /open chat/i })
   expect(screen.queryByTestId('chat-component')).toBeNull()
   fireEvent.click(button)

--- a/src/views/Home/Home.tsx
+++ b/src/views/Home/Home.tsx
@@ -5,7 +5,6 @@ import Dialog from '@mui/material/Dialog'
 import Fab from '@mui/material/Fab'
 import Typography from '@mui/material/Typography'
 import ChatIcon from '@mui/icons-material/Chat'
-import { ChatProvider } from '@/contexts/ChatContext'
 import Chat from '@/components/Chat/Chat'
 import Image from '@/components/Image'
 import styles from '@/views/Home/Home.module.scss'
@@ -122,51 +121,49 @@ const Home: React.FC = () => {
           </a>
         </Box>
       </Box>
-      <ChatProvider>
-        <Fab
-          ref={chatButtonRef}
-          id="chat-button"
-          aria-label={chatOpen ? 'close chat' : 'open chat'}
-          aria-expanded={chatOpen}
-          aria-controls="chat-dialog"
-          color="info"
-          onClick={toggleChat}
-          size="large"
-          sx={{
-            position: 'fixed',
-            bottom: 16,
-            right: 16,
-          }}
-        >
-          <ChatIcon />
-        </Fab>
-        <Dialog
-          open={chatOpen}
-          onClose={toggleChat}
-          aria-labelledby="chat-dialog-title"
-          aria-describedby="chat-dialog-description"
-          id="chat-dialog"
-          slotProps={{
-            paper: {
-              sx: {
-                position: 'fixed',
-                bottom: 80,
-                right: 16,
-                m: 0,
-                width: {
-                  xs: 'calc(100% - 32px)',
-                  sm: 350,
-                  md: 400,
-                  lg: 450,
-                },
-                maxHeight: 'calc(100% - 96px)',
+      <Fab
+        ref={chatButtonRef}
+        id="chat-button"
+        aria-label={chatOpen ? 'close chat' : 'open chat'}
+        aria-expanded={chatOpen}
+        aria-controls="chat-dialog"
+        color="info"
+        onClick={toggleChat}
+        size="large"
+        sx={{
+          position: 'fixed',
+          bottom: 16,
+          right: 16,
+        }}
+      >
+        <ChatIcon />
+      </Fab>
+      <Dialog
+        open={chatOpen}
+        onClose={toggleChat}
+        aria-labelledby="chat-dialog-title"
+        aria-describedby="chat-dialog-description"
+        id="chat-dialog"
+        slotProps={{
+          paper: {
+            sx: {
+              position: 'fixed',
+              bottom: 80,
+              right: 16,
+              m: 0,
+              width: {
+                xs: 'calc(100% - 32px)',
+                sm: 350,
+                md: 400,
+                lg: 450,
               },
+              maxHeight: 'calc(100% - 96px)',
             },
-          }}
-        >
-          <Chat onClose={toggleChat} />
-        </Dialog>
-      </ChatProvider>
+          },
+        }}
+      >
+        <Chat onClose={toggleChat} />
+      </Dialog>
     </Container>
   )
 }


### PR DESCRIPTION
## Summary

### Added

- Added a focused root wiring test to prove routed children receive shared chat context.

### Changed

- Moved chat state ownership to the root provider so both `Home` and the authenticated shell resolve the same `ChatProvider`.
- Simplified `AppLayout` to consume typed loader data directly instead of using `Suspense` and `Await` as an auth boundary.
- Simplified `AuthProvider` so it only manages auth state hydration and no longer carries dead router-navigation scaffolding.

### Fixed

- Protected `/app` at the router layer by making `authLoader` return typed auth data and redirect unauthenticated access to `Routes.AUTH_LOGIN`.
- Fixed inconsistent chat provider placement that left the authenticated shell without working chat state.
- Updated auth and chat tests to match the router-owned auth gate and shared chat context model.

## How to test

- Run:
  - `NODE_ENV=test yarn exec jest --runInBand --coverage=false --runTestsByPath src/store/auth/AuthProvider.test.tsx src/router/router.test.ts src/layouts/AppLayout/AppLayout.test.tsx src/components/Chat/Chat.test.tsx src/views/Home/Home.test.tsx src/contexts/ChatContext.Root.test.tsx`
- Verify unauthenticated `/app` access redirects to `/auth/login`.
- Verify chat state is shared across `Home` and the authenticated shell.
