### PR TITLE
fix(app): address PR #226 review comments

### DIFF
--- a/src/layouts/AppLayout/AppLayout.test.tsx
+++ b/src/layouts/AppLayout/AppLayout.test.tsx
@@ -16,8 +16,8 @@ test('renders the main application layout', () => {
   render(<AppLayout />, { wrapper: (props) => <BrowserRouter {...props} /> })
 
   expect(screen.getByTestId('app')).toHaveAttribute(
-    'data-jwt-token',
-    'jwt-token'
+    'data-authenticated',
+    'true'
   )
   expect(screen.getByTestId('appbar-title')).toHaveTextContent(DASHBOARD_TITLE)
   expect(screen.getByRole('button', { name: /login/i })).toBeInTheDocument()

--- a/src/layouts/AppLayout/AppLayout.tsx
+++ b/src/layouts/AppLayout/AppLayout.tsx
@@ -86,7 +86,7 @@ const AppLayout: React.FC = (): React.JSX.Element => {
       <CssBaseline />
       <Box
         data-testid="app"
-        data-jwt-token={jwtToken}
+        data-authenticated={Boolean(jwtToken)}
         sx={{
           display: 'flex',
           flexGrow: 1,

--- a/src/router/router.test.ts
+++ b/src/router/router.test.ts
@@ -1,4 +1,3 @@
-import { redirect } from 'react-router-dom'
 import router from './router'
 import authLoader from './authLoader'
 import { RouteIds, Routes } from './constants'
@@ -47,6 +46,12 @@ describe('router configuration', () => {
 
     mockGetJWT.mockRejectedValue(unauthorized)
 
-    await expect(authLoader()).rejects.toEqual(redirect(Routes.AUTH_LOGIN))
+    const redirectResponse = await authLoader().catch(
+      (error) => error as Response
+    )
+
+    expect(redirectResponse).toBeInstanceOf(Response)
+    expect(redirectResponse.status).toBe(302)
+    expect(redirectResponse.headers.get('Location')).toBe(Routes.AUTH_LOGIN)
   })
 })

--- a/src/store/auth/AuthProvider.test.tsx
+++ b/src/store/auth/AuthProvider.test.tsx
@@ -84,11 +84,13 @@ describe('AuthProvider', () => {
     render(<Content />)
     await flushEffects()
 
-    expect(mockGetCurrentUser).toHaveBeenCalled()
-    expect(mockFetchAuthSession).toHaveBeenCalledTimes(1)
-    expect(screen.getByTestId('auth-error')).toHaveTextContent(
-      'Initialization error'
-    )
+    await waitFor(() => {
+      expect(mockGetCurrentUser).toHaveBeenCalled()
+      expect(mockFetchAuthSession).toHaveBeenCalledTimes(1)
+      expect(screen.getByTestId('auth-error')).toHaveTextContent(
+        'Initialization error'
+      )
+    })
   })
 
   test('dispatches login success with the refreshed jwt token when one is returned', async () => {


### PR DESCRIPTION
## Summary

### Changed

- Replaced the raw JWT DOM marker in the app shell with a non-sensitive authenticated flag.
- Tightened the auth-loader redirect test to assert the thrown response status and `Location` header directly.
- Made the auth-provider failure test wait for reducer-driven UI updates before asserting error state.

### Fixed

- Addressed all applicable review comments from PR #226.

## How to test

- Run:
  - `NODE_ENV=test yarn jest --coverage --colors --runInBand --runTestsByPath src/layouts/AppLayout/AppLayout.test.tsx src/router/router.test.ts src/store/auth/AuthProvider.test.tsx`
